### PR TITLE
Don't overwrite default options while making a copy

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,7 @@ const existsAsync = (path) => new Promise((resolve) => {
 });
 class FallbackDirectoryResolverPlugin {
     constructor(options = {}) {
-        this.options = Object.assign(FallbackDirectoryResolverPlugin.defaultOptions, options);
+        this.options = Object.assign({}, FallbackDirectoryResolverPlugin.defaultOptions, options);
         this.pathRegex = new RegExp(`^#${this.options.prefix}#/`);
         this.cache = {};
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export class FallbackDirectoryResolverPlugin {
     private cache: { [key: string]: Promise<string> };
 
     public constructor(options: IFallbackDirectoryResolverPluginOptions = {}) {
-        this.options = Object.assign(FallbackDirectoryResolverPlugin.defaultOptions, options);
+        this.options = Object.assign({}, FallbackDirectoryResolverPlugin.defaultOptions, options);
         this.pathRegex = new RegExp(`^#${this.options.prefix}#/`);
         this.cache = {};
     }


### PR DESCRIPTION
Object.assign needs the first parameter to be the target, so it should be an empty object in this case.

Run this sample code to see the issue:

```
class MyClass {
  constructor(options = {}) {
    this.options = Object.assign(MyClass.defaultOptions, options);
    this.staticProperty = options.staticProperty;
  }
}
MyClass.defaultOptions = {
    staticProperty: 'classDefault',
    anotherProperty: 'anotherDefault',
};

let a = new MyClass({staticProperty: 'classA'});
console.log(MyClass.defaultOptions);
let b = new MyClass({staticProperty: 'classB'});
console.log(MyClass.defaultOptions);
```